### PR TITLE
Updated proxycannon-client.conf key and cert file names

### DIFF
--- a/setup/configs/proxycannon-client.conf
+++ b/setup/configs/proxycannon-client.conf
@@ -12,7 +12,7 @@ remote-cert-tls server
 tls-auth ta.key 1
 auth SHA256
 ca ca.crt
-cert client1.crt
-key client1.key
+cert client01.crt
+key client01.key
 cipher AES-256-CBC
 comp-lzo


### PR DESCRIPTION
I got the folliwing when not changed:
```bash
Options error: --cert fails with 'client1.crt': No such file or directory (errno=2)
Wed Oct 31 15:15:04 2018 WARNING: cannot stat file 'client1.key': No such file or directory (errno=2)
Options error: --key fails with 'client1.key': No such file or directory (errno=2)
Options error: Please correct these errors.
Use --help for more information.
```