### PR TITLE
Removed "comp-lzo" setting from client config

### DIFF
--- a/setup/configs/proxycannon-client.conf
+++ b/setup/configs/proxycannon-client.conf
@@ -15,4 +15,3 @@ ca ca.crt
 cert client01.crt
 key client01.key
 cipher AES-256-CBC
-comp-lzo


### PR DESCRIPTION
Was getting "WARNING: 'comp-lzo' is present in local config but missing in remote config, local='comp-lzo'" warning on the client side, and "IP packet with unknown IP version=15 seen" on the server side due to compression mismatch between client and server. Since server is configured without "comp-lzo" setting the client should also be configured the same.