### PR TITLE
Get default interface instead of defaulting to eth0

### DIFF
--- a/nodes/aws/configs/node_setup.bash
+++ b/nodes/aws/configs/node_setup.bash
@@ -1,3 +1,4 @@
 #! /bin/bash
 sudo sysctl -w net.ipv4.ip_forward=1
-sudo iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
+DEFAULTETH=`ip route | grep default | sed -e "s/^.*dev.//" -e "s/.proto.*//"``
+sudo iptables -t nat -A POSTROUTING -o $DEFAULTETH -j MASQUERADE

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -70,8 +70,9 @@ echo "50        loadb" >> /etc/iproute2/rt_tables
 # set rule for openvpn client source network to use the second routing table
 ip rule add from 10.10.10.0/24 table loadb
 
-# always snat from eth0
-iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
+# always snat from default ethernet
+DEFAULTETH=`ip route | grep default | sed -e "s/^.*dev.//" -e "s/.proto.*//"`
+iptables -t nat -A POSTROUTING -o $DEFAULTETH -j MASQUERADE
 
 ############################
 # post install instructions


### PR DESCRIPTION
This change pulls the name of the interface named as the default route and uses that for iptables masquerade setting, instead of defaulting to eth0.

This allows the project to work on other instances that don't have an eth0 (t3 series for example)