### PR TITLE
Move size and AMI image options to variables.tf

### DIFF
--- a/nodes/aws/main.tf
+++ b/nodes/aws/main.tf
@@ -4,8 +4,8 @@ provider "aws" {
 }
 
 resource "aws_instance" "exit-node" {
-  ami           = "ami-0f65671a86f061fcd"
-  instance_type = "t2.micro"
+  ami           = "${var.ami}"
+  instance_type = "${var.size}"
   key_name      = "proxycannon"
   vpc_security_group_ids = ["${aws_security_group.exit-node-sec-group.id}"]
   subnet_id	= "${var.subnet_id}"

--- a/nodes/aws/variables.tf
+++ b/nodes/aws/variables.tf
@@ -7,6 +7,13 @@ variable "count" {
   default = 2
 }
 
+variable "ami" {
+  default = "ami-0f65671a86f061fcd"
+}
+variable "size" {
+  default = "t2.micro"
+}
+
 # launch all exit nodes in the same subnet id
 # this should be the same subnet id that your control server is in
 # you can get this value from the AWS console when viewing the details of the control-server instance

--- a/nodes/aws/variables.tf
+++ b/nodes/aws/variables.tf
@@ -7,9 +7,12 @@ variable "count" {
   default = 2
 }
 
+# AMI image to use for exit nodes
 variable "ami" {
   default = "ami-0f65671a86f061fcd"
 }
+
+# Size of EC2 VM to spin up for exit nodes
 variable "size" {
   default = "t2.micro"
 }


### PR DESCRIPTION
Moving AMI image and EC2 size to variables.tf to make updating these values a little easier.