### PR TITLE
Firewall rule update

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,10 @@ Perform the following on the control-server:
 2. Run `terraform init` to download the AWS modules. (you only need to do this once)
 
 #### 5. Copy OpenVPN files to your workstation
-Copy the following files from the control-server to the `/etc/openvpn` directory on your workstation:
-- ~/proxycannon-client.conf
-- /etc/openvpn/easy-rsa/keys/ta.key
-- /etc/openvpn/easy-rsa/keys/ca.crt
-- /etc/openvpn/easy-rsa/keys/client01.crt
-- /etc/openvpn/easy-rsa/keys/client01.key  
+Copy the contents of the ~/proxycannon-vpn-client folder on your workstation:
+```
+scp -i proxycannon.pem ubuntu@<external_ip>:/home/ubuntu/proxycannon-vpn-client/* .
+```
 
 Test OpenVPN connectivity from your workstation by running:
 ```

--- a/nodes/aws/configs/node_setup.bash
+++ b/nodes/aws/configs/node_setup.bash
@@ -1,4 +1,4 @@
 #! /bin/bash
 sudo sysctl -w net.ipv4.ip_forward=1
-DEFAULTETH=`ip route | grep default | sed -e "s/^.*dev.//" -e "s/.proto.*//"``
+DEFAULTETH=`ip route | grep default | sed -e "s/^.*dev.//" -e "s/.proto.*//"`
 sudo iptables -t nat -A POSTROUTING -o $DEFAULTETH -j MASQUERADE

--- a/nodes/aws/configs/node_setup.bash
+++ b/nodes/aws/configs/node_setup.bash
@@ -1,3 +1,4 @@
 #! /bin/bash
 sudo sysctl -w net.ipv4.ip_forward=1
-sudo iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
+DEFAULTETH=`ip route | grep default | sed -e "s/^.*dev.//" -e "s/.proto.*//"``
+sudo iptables -t nat -A POSTROUTING -o $DEFAULTETH -j MASQUERADE

--- a/nodes/aws/main.tf
+++ b/nodes/aws/main.tf
@@ -67,7 +67,7 @@ resource "aws_security_group" "exit-node-sec-group" {
     from_port   = 0
     to_port     = 0 
     protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = "${var.allowedips}"
   }
 }
 

--- a/nodes/aws/main.tf
+++ b/nodes/aws/main.tf
@@ -4,8 +4,8 @@ provider "aws" {
 }
 
 resource "aws_instance" "exit-node" {
-  ami           = "ami-0f65671a86f061fcd"
-  instance_type = "t2.micro"
+  ami           = "${var.ami}"
+  instance_type = "${var.size}"
   key_name      = "proxycannon"
   vpc_security_group_ids = ["${aws_security_group.exit-node-sec-group.id}"]
   subnet_id	= "${var.subnet_id}"

--- a/nodes/aws/variables.tf
+++ b/nodes/aws/variables.tf
@@ -19,6 +19,7 @@ variable "size" {
 
 variable "allowedips" {
   default = [
+    "CONTROLSERVERPUBLICIP/32",
     "CONTROLSERVERPRIVATEIP/32"
   ]
 }

--- a/nodes/aws/variables.tf
+++ b/nodes/aws/variables.tf
@@ -17,6 +17,12 @@ variable "size" {
   default = "t2.micro"
 }
 
+variable "allowedips" {
+  default = [
+    "CONTROLSERVERPRIVATEIP/32"
+  ]
+}
+
 # launch all exit nodes in the same subnet id
 # this should be the same subnet id that your control server is in
 # you can get this value from the AWS console when viewing the details of the control-server instance

--- a/nodes/aws/variables.tf
+++ b/nodes/aws/variables.tf
@@ -7,6 +7,16 @@ variable "count" {
   default = 2
 }
 
+# AMI image to use for exit nodes
+variable "ami" {
+  default = "ami-0f65671a86f061fcd"
+}
+
+# Size of EC2 VM to spin up for exit nodes
+variable "size" {
+  default = "t2.micro"
+}
+
 # launch all exit nodes in the same subnet id
 # this should be the same subnet id that your control server is in
 # you can get this value from the AWS console when viewing the details of the control-server instance

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -36,6 +36,8 @@ SUBNETID=`curl http://169.254.169.254/latest/meta-data/network/interfaces/macs/$
 sed -i "s/subnet-XXXXXXXX/$SUBNETID/" ../nodes/aws/variables.tf
 PRIVATEIP=`curl http://169.254.169.254/latest/meta-data/network/interfaces/macs/$MAC/local-ipv4s`
 sed -i "s/CONTROLSERVERPRIVATEIP/$PRIVATEIP/" ../nodes/aws/variables.tf
+EIP=`curl -s http://169.254.169.254/latest/meta-data/public-ipv4`
+sed -i "s/CONTROLSERVERPUBLICIP/$EIP/" ../nodes/aws/variables.tf
 
 ################
 # setup openvpn
@@ -67,7 +69,6 @@ systemctl start openvpn@node-server.service
 systemctl start openvpn@client-server.service
 
 # modify client config with remote IP of this server
-EIP=`curl -s http://169.254.169.254/latest/meta-data/public-ipv4`
 sed -i "s/REMOTE_PUB_IP/$EIP/" ~/proxycannon-client.conf
 
 ###################

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -28,13 +28,14 @@ region = us-east-2
 EOF
 chown -R $SUDO_USER:$SUDO_USER ~/.aws
 
-##################################
-# update subnet id in variables.tf
-##################################
+####################################################
+# update subnet id and firewall rule in variables.tf
+####################################################
 MAC=`curl http://169.254.169.254/latest/meta-data/network/interfaces/macs/`
 SUBNETID=`curl http://169.254.169.254/latest/meta-data/network/interfaces/macs/$MAC/subnet-id`
 sed -i "s/subnet-XXXXXXXX/$SUBNETID/" ../nodes/aws/variables.tf
-
+PRIVATEIP=`curl http://169.254.169.254/latest/meta-data/network/interfaces/macs/$MAC/local-ipv4s`
+sed -i "s/CONTROLSERVERPRIVATEIP/$PRIVATEIP/" ../nodes/aws/variables.tf
 
 ################
 # setup openvpn

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -21,6 +21,14 @@ rm -rf terraform
 mkdir ~/.aws
 touch ~/.aws/credentials
 
+##################################
+# update subnet id in variables.tf
+##################################
+MAC=`curl http://169.254.169.254/latest/meta-data/network/interfaces/macs/`
+SUBNETID=`curl http://169.254.169.254/latest/meta-data/network/interfaces/macs/$MAC/subnet-id`
+sed -i "s/subnet-XXXXXXXX/$SUBNETID/" ../nodes/aws/variables.tf
+
+
 ################
 # setup openvpn
 ################
@@ -83,8 +91,6 @@ cp /etc/openvpn/easy-rsa/keys/client01.crt ~/proxycannon-vpn-client/
 cp /etc/openvpn/easy-rsa/keys/client01.key ~/proxycannon-vpn-client/
 mv ~/proxycannon-client.conf ~/proxycannon-vpn-client/
 chown -R $SUDO_USER:$SUDO_USER ~/proxycannon-vpn-client
-
-
 
 ############################
 # post install instructions

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -78,8 +78,9 @@ echo "50        loadb" >> /etc/iproute2/rt_tables
 # set rule for openvpn client source network to use the second routing table
 ip rule add from 10.10.10.0/24 table loadb
 
-# always snat from eth0
-iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
+# always snat from default ethernet
+DEFAULTETH=`ip route | grep default | sed -e "s/^.*dev.//" -e "s/.proto.*//"`
+iptables -t nat -A POSTROUTING -o $DEFAULTETH -j MASQUERADE
 
 #######################################
 # collect vpn config files to one place

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -8,7 +8,7 @@
 # update and install deps
 apt update
 apt -y upgrade
-apt -y install unzip git openvpn easy-rsa
+apt -y install zip unzip git openvpn easy-rsa
 
 # install terraform
 wget https://releases.hashicorp.com/terraform/0.11.10/terraform_0.11.10_linux_amd64.zip
@@ -73,14 +73,30 @@ ip rule add from 10.10.10.0/24 table loadb
 # always snat from eth0
 iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
 
+#######################################
+# collect vpn config files to one place
+#######################################
+mkdir ~/proxycannon-vpn-client
+cp /etc/openvpn/easy-rsa/keys/ta.key ~/proxycannon-vpn-client/
+cp /etc/openvpn/easy-rsa/keys/ca.crt ~/proxycannon-vpn-client/
+cp /etc/openvpn/easy-rsa/keys/client01.crt ~/proxycannon-vpn-client/
+cp /etc/openvpn/easy-rsa/keys/client01.key ~/proxycannon-vpn-client/
+mv ~/proxycannon-client.conf ~/proxycannon-vpn-client/
+chown -R $SUDO_USER:$SUDO_USER ~/proxycannon-vpn-client
+
+
+
 ############################
 # post install instructions
 ############################
 
-echo "Copy /etc/openvpn/easy-rsa/keys/ta.key, /etc/openvpn/easy-rsa/keys/ca.crt, /etc/openvpn/easy-rsa/keys/client01.crt, /etc/openvpn/easy-rsa/keys/client01.key, and ~/proxycannon-client.conf to your workstation."
-
+echo "A folder containing the OpenVPN client config has been created at /home/$SUDO_USER/proxycannon-vpn-client."
+echo "Download these files by running the following from your workstation (including the trailing period): "
+echo
+echo "scp -i proxycannon.pem $SUDO_USER@$EIP:/home/$SUDO_USER/proxycannon-vpn-client/* ."
+echo 
 echo "####################### OpenVPN client config [proxycannon-client.conf] ################################"
-cat ~/proxycannon-client.conf
+cat ~/proxycannon-vpn-client/proxycannon-client.conf
 
 echo "####################### Be sure to add your AWS API keys and SSH keys to the following locations ###################"
 echo "copy your aws ssh private key to ~/.ssh/proxycannon.pem and chmod 600"

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -20,6 +20,13 @@ rm -rf terraform
 # create directory for our aws credentials
 mkdir ~/.aws
 touch ~/.aws/credentials
+cat << EOF >> ~/.aws/credentials
+[default]
+aws_access_key_id = REPLACE_WITH_YOUR_OWN
+aws_secret_access_key = REPLACE_WITH_YOUR_OWN
+region = us-east-2
+EOF
+chown -R $SUDO_USER:$SUDO_USER ~/.aws
 
 ##################################
 # update subnet id in variables.tf


### PR DESCRIPTION
This updates the security group for the exit nodes to only allow inbound traffic from the public and private ips of the control server. 

This PR is based on all of the PRs I've submitted so far because I'm dumb and don't know how to use git properly. There's a lot of changes here that are just part of previous PRs. Let me know if you want me to clean this up and I'll be happy to resubmit.

Relevant file changes are
* /nodes/aws/variables.tf - Add the inboundips variable
* /nodes/aws/main.tf - change firewall rule to use inboundips variable
* /setup/install.sh - Get public and private ips from AWS metadata and put them in variables.tf (lines 37- 40)

Thanks!