### PR TITLE
Notes and changes following updates to terraform

### DIFF
--- a/nodes/aws/variables.tf
+++ b/nodes/aws/variables.tf
@@ -3,7 +3,7 @@ variable "aws_priv_key" {
 }
 
 # number of exit-node instances to launch
-variable "count" {
+variable "exit_nodes" {
   default = 2
 }
 


### PR DESCRIPTION
terraform has updated their gpg key at this time, requiring an update of the tool or disabling of security checks to install and launch a control server following the directions in the readme. following that update, these changes are proposed to resolve the following issues:

│ Error: Invalid variable name
│
│   on variables.tf line 6, in variable "count":
│    6: variable "count" {
│
│ The variable name "count" is reserved due to its special meaning inside module blocks.

action: changed variable "count" to "exit_nodes"