### PR TITLE
Notes and changes following updates to terraform

### DIFF
--- a/nodes/aws/main.tf
+++ b/nodes/aws/main.tf
@@ -11,7 +11,7 @@ resource "aws_instance" "exit-node" {
   subnet_id	= "${var.subnet_id}"
   # we need to disable this for internal routing
   source_dest_check	= false
-  count		= "${var.count}"
+  exit_nodes		= "${var.exit_nodes}"
 
 
   tags {
@@ -48,7 +48,7 @@ resource "aws_instance" "exit-node" {
 
   # modify our route table when we destroy an exit-node
   provisioner "local-exec" {
-    when = "destroy"
+    when = destroy
     command = "sudo ./del_route.bash ${self.private_ip}"
   }
 


### PR DESCRIPTION
terraform has updated their gpg key at this time, requiring an update of the tool or disabling of security checks to install and launch a control server following the directions in the readme. following that update, these changes are proposed to resolve the following issues:

│ Warning: Quoted keywords are deprecated
│
│   on main.tf line 51, in resource "aws_instance" "exit-node":
│   51:     when = "destroy"
│
│ In this context, keywords are expected literally rather than in quotes. Terraform 0.11 and earlier required quotes,
│ but quoted keywords are now deprecated and will be removed in a future version of Terraform. Remove the quotes
│ surrounding this keyword to silence this warning.
 
action: removed quotations

│ Error: Invalid variable name
│
│   on variables.tf line 6, in variable "count":
│    6: variable "count" {
│
│ The variable name "count" is reserved due to its special meaning inside module blocks.

action: changed variable "count" to "exit_nodes"